### PR TITLE
Fix issue where splice was only being applied to the last heading

### DIFF
--- a/js/jquery.tableofcontents.js
+++ b/js/jquery.tableofcontents.js
@@ -77,16 +77,12 @@
 			base.$headings = base.$scope.find(filtered_tags.join(', '));
 
 			if (base.options.ignoreClass !== "") {
-				var ignoreClassIndex;
 				base.$headings.each(function(i,element) {
 					$this = $(this);
 					if ($this.hasClass(base.options.ignoreClass)) {
-						ignoreClassIndex = i;
+                      base.$headings.splice(i, 1);
 					}
 				});
-				if(ignoreClassIndex) {
-					base.$headings.splice(ignoreClassIndex, 1);
-				}
 			}
 			
 			// If topLinks is enabled, set/get an id for the body element


### PR DESCRIPTION
The ignoreClassIndex var was being overridden by later instances of the ignored class, so I've removed it entirely and spliced inside the loop.
